### PR TITLE
truncate game description on index

### DIFF
--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -86,7 +86,7 @@
                     <div class="game-card-text">
                       <p class="mb-0 game-title"><%= game.title %></p>
                       <p class="game-tag"><%="##{game.category}"%></p>
-                      <p class="game-description text-break"><%= game.description %></p>
+                      <p class="game-description text-break"><%= game.description.truncate(150) %></p>
                         <%= form_tag orders_path do %>
                         <%= hidden_field_tag 'game_id', game.id %>
                         <%= submit_tag humanized_money_with_symbol(game.price), class:"game-card-button"%>


### PR DESCRIPTION
truncated the game description on each of the cards to avoid the description overlapping with the price button